### PR TITLE
update default contact email to info@pna

### DIFF
--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -1,5 +1,5 @@
 class ContactMailer < ActionMailer::Base
-  default to: 'salbanese0080@gmail.com' #ENV[ 'CONTACT_MAIL_TO' ]
+  default to: 'info@paddlesportsnorthamerica.org' #ENV[ 'CONTACT_MAIL_TO' ]
 
   def contact_email( message )
     @message = message


### PR DESCRIPTION
sets the default contact email address to info@paddlesportsnorthamerica.org